### PR TITLE
Out of memory exception on image listing

### DIFF
--- a/src/android/Library/src/ImageFetcher.java
+++ b/src/android/Library/src/ImageFetcher.java
@@ -203,6 +203,7 @@ public class ImageFetcher {
 	                }
 	            }
         	}catch(OutOfMemoryError error) {
+        		clearCache();
         		return null;
         	}
 
@@ -282,7 +283,7 @@ public class ImageFetcher {
      * Garbage Collector.
      */
 
-    private static final int HARD_CACHE_CAPACITY = 0;
+    private static final int HARD_CACHE_CAPACITY = 100;
     private static final int DELAY_BEFORE_PURGE = 10 * 1000; // in milliseconds
 
     // Hard cache, with a fixed maximum capacity and a life duration
@@ -366,8 +367,8 @@ public class ImageFetcher {
      * after a certain inactivity delay.
      */
     public void clearCache() {
-        // sHardBitmapCache.clear();
-        // sSoftBitmapCache.clear();
+        sHardBitmapCache.clear();
+        sSoftBitmapCache.clear();
     }
 
     /**


### PR DESCRIPTION
This PR will fix #22 and probably #17.
Setting largeHeap=true (http://developer.android.com/guide/topics/manifest/application-element.html#largeHeap) for the application makes is more responsive while fetching images.
