### PR TITLE
Remove tag that prevents build from working on android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -66,7 +66,6 @@
 		
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
 		    <activity android:label="@string/multi_app_name" android:name="com.synconset.MultiImageChooserActivity" android:theme="@android:style/Theme.Holo.Light">
-                <intent-filter />
             </activity>
 		</config-file>
 		


### PR DESCRIPTION
When building for android (cordova android 4.0 + crosswalk) I get the following error:
"Missing one of the key attributes 'action#name,category#name' on element intent-filter at AndroidManifest.xml:24:13"

When removing the empty intent-filter tag this fixes the problem and allows the build to work.