### PR TITLE
iOS bug fix: scaling sometimes resulted in "white lines" on the right and/or bottom of the output image

### DIFF
--- a/src/ios/SOSPicker.m
+++ b/src/ios/SOSPicker.m
@@ -27,7 +27,7 @@
 
 	// Create the an album controller and image picker
 	ELCAlbumPickerController *albumController = [[ELCAlbumPickerController alloc] init];
-	
+
 	if (maximumImagesCount == 1) {
       albumController.immediateReturn = true;
       albumController.singleSelection = true;
@@ -35,7 +35,7 @@
       albumController.immediateReturn = false;
       albumController.singleSelection = false;
    }
-   
+
    ELCImagePickerController *imagePicker = [[ELCImagePickerController alloc] initWithRootViewController:albumController];
    imagePicker.maximumImagesCount = maximumImagesCount;
    imagePicker.returnsOriginalImage = 1;
@@ -69,11 +69,11 @@
         do {
             filePath = [NSString stringWithFormat:@"%@/%@%03d.%@", docsPath, CDV_PHOTO_PREFIX, i++, @"jpg"];
         } while ([fileMgr fileExistsAtPath:filePath]);
-        
+
         @autoreleasepool {
             ALAssetRepresentation *assetRep = [asset defaultRepresentation];
             CGImageRef imgRef = NULL;
-            
+
             //defaultRepresentation returns image as it appears in photo picker, rotated and sized,
             //so use UIImageOrientationUp when creating our image below.
             if (picker.returnsOriginalImage) {
@@ -82,7 +82,7 @@
             } else {
                 imgRef = [assetRep fullScreenImage];
             }
-            
+
             UIImage* image = [UIImage imageWithCGImage:imgRef scale:1.0f orientation:orientation];
             if (self.width == 0 && self.height == 0) {
                 data = UIImageJPEGRepresentation(image, self.quality/100.0f);
@@ -90,7 +90,7 @@
                 UIImage* scaledImage = [self imageByScalingNotCroppingForSize:image toSize:targetSize];
                 data = UIImageJPEGRepresentation(scaledImage, self.quality/100.0f);
             }
-            
+
             if (![data writeToFile:filePath options:NSAtomicWrite error:&err]) {
                 result = [CDVPluginResult resultWithStatus:CDVCommandStatus_IO_EXCEPTION messageAsString:[err localizedDescription]];
                 break;
@@ -100,7 +100,7 @@
         }
 
 	}
-	
+
 	if (nil == result) {
 		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:resultStrings];
 	}
@@ -143,7 +143,7 @@
         } else {
             scaleFactor = widthFactor; // scale to fit width
         }
-        scaledSize = CGSizeMake(width * scaleFactor, height * scaleFactor);
+        scaledSize = CGSizeMake(floor(width * scaleFactor), floor(height * scaleFactor));
     }
 
     UIGraphicsBeginImageContext(scaledSize); // this will resize


### PR DESCRIPTION
Fixed bug where some images got a white line on the right or bottom after scaling. 

For example, if the input image is a 1500x1001 pixels, the output has a white line on the bottom. Easy to see if the source image is dark / all black.

I didn't look at the other platforms. They may have the same bug.
