### PR TITLE
Updated version to 1.0.7

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="com.synconset.imagepicker"
-  version="1.0.6">
+  version="1.0.7">
 
 	<name>ImagePicker</name>
 	 


### PR DESCRIPTION
Hello,

The latest version, v1.0.6, will not build for Android.  

This issue was fixed in 9012443afed22d4267650a4a184d4fad879e8268, however a new release has not been cut.

Thanks,
Kyle