### PR TITLE
Fix android application crash when image file name is less than 3 characters.

### DIFF
--- a/src/android/Library/src/MultiImageChooserActivity.java
+++ b/src/android/Library/src/MultiImageChooserActivity.java
@@ -615,7 +615,7 @@ public class MultiImageChooserActivity extends Activity implements OnItemClickLi
         */
         private File storeImage(Bitmap bmp, String fileName) throws IOException {
             int index = fileName.lastIndexOf('.');
-            String name = fileName.substring(0, index);
+            String name = "temp_"+fileName.substring(0, index);
             String ext = fileName.substring(index);
             File file = File.createTempFile(name, ext);
             OutputStream outStream = new FileOutputStream(file);


### PR DESCRIPTION
Android application crash when selecting image with less than 3 characters file name. 
(Error when call File.createTempFile - prefix must be at least 3 characters)

Fixed by prepend "temp_" to temporary file name before create temp file.