### PR TITLE
Add compulsory prefix "tmp_" to temporary filename

### DIFF
--- a/src/android/Library/src/MultiImageChooserActivity.java
+++ b/src/android/Library/src/MultiImageChooserActivity.java
@@ -617,7 +617,7 @@ public class MultiImageChooserActivity extends Activity implements OnItemClickLi
             int index = fileName.lastIndexOf('.');
             String name = fileName.substring(0, index);
             String ext = fileName.substring(index);
-            File file = File.createTempFile(name, ext);
+            File file = File.createTempFile("tmp_" + name, ext);
             OutputStream outStream = new FileOutputStream(file);
             if (ext.compareToIgnoreCase(".png") == 0) {
                 bmp.compress(Bitmap.CompressFormat.PNG, quality, outStream);


### PR DESCRIPTION
Fixes Issue #86 .

The call to `File.createTempFile` causes an `IllegalArgumentException` as it is expecting the filename parameter to be > 3 characters. Therefore a fatal error occurs when filename prefixes are less than 3 characters e.g.: 3.jpg, ab.jpg etc.

To fix this I have added a compulsory prefix to the created temporary file.

As far as I can see this change will have little negative flow on effect.