### PR TITLE
Add plugin to npm registry / cordova plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cordova-plugin-imagepicker",
+  "version": "1.0.7",
+  "description": "This plugin allows selection of multiple images from the camera roll / gallery in a phonegap app",
+  "cordova": {
+    "id": "cordova-plugin-imagepicker",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wymsee/cordova-plugin-imagepicker"
+  },
+  "keywords": [
+    "ecosystem:cordova",
+    "cordova-android",
+    "cordova-ios"
+  ],
+  "license": "Apache 2.0"
+}


### PR DESCRIPTION
Currently it's not possible to use your plugin with phonegap build. The old phonegap build plugin repository is deprecated.
Please add your plugin to the [npm registry](https://docs.npmjs.com/getting-started/publishing-npm-packages).

http://cordova.apache.org/plugins/authors.html

Thanks :)