### PR TITLE
Fix cordova 5 build errors

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -99,12 +99,6 @@
 		<source-file src="src/android/Library/res/layout/multiselectorgrid.xml" target-dir="res/layout"/>
 		<source-file src="src/android/Library/res/values/multiimagechooser_strings_en.xml" target-dir="res/values"/>
 		<source-file src="src/android/Library/res/values/themes.xml" target-dir="res/values"/>
-		
-		<source-file src="src/android/Library/res/values-de/multiimagechooser_strings_de.xml" target-dir="res/values-de"/>
-		<source-file src="src/android/Library/res/values-es/multiimagechooser_strings_es.xml" target-dir="res/values-es"/>
-		<source-file src="src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml" target-dir="res/values-fr"/>
-		<source-file src="src/android/Library/res/values-hu/multiimagechooser_strings_hu.xml" target-dir="res/values-hu"/>
-		<source-file src="src/android/Library/res/values-ja/multiimagechooser_strings_ja.xml" target-dir="res/values-ja"/>
-		<source-file src="src/android/Library/res/values-ko/multiimagechooser_strings_ko.xml" target-dir="res/values-ko"/>
+	
 	</platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -99,6 +99,12 @@
 		<source-file src="src/android/Library/res/layout/multiselectorgrid.xml" target-dir="res/layout"/>
 		<source-file src="src/android/Library/res/values/multiimagechooser_strings_en.xml" target-dir="res/values"/>
 		<source-file src="src/android/Library/res/values/themes.xml" target-dir="res/values"/>
-	
+		
+		<source-file src="src/android/Library/res/values-de/multiimagechooser_strings_de.xml" target-dir="res/values-de"/>
+		<source-file src="src/android/Library/res/values-es/multiimagechooser_strings_es.xml" target-dir="res/values-es"/>
+		<source-file src="src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml" target-dir="res/values-fr"/>
+		<source-file src="src/android/Library/res/values-hu/multiimagechooser_strings_hu.xml" target-dir="res/values-hu"/>
+		<source-file src="src/android/Library/res/values-ja/multiimagechooser_strings_ja.xml" target-dir="res/values-ja"/>
+		<source-file src="src/android/Library/res/values-ko/multiimagechooser_strings_ko.xml" target-dir="res/values-ko"/>
 	</platform>
 </plugin>

--- a/src/android/Library/res/values-de/multiimagechooser_strings_de.xml
+++ b/src/android/Library/res/values-de/multiimagechooser_strings_de.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="multi_app_name">MultiImageChooser</string>
-    <string name="free_version_label">Free version - Images left: %d</string>
-    <string name="error_database">There was an error opening the images database. Please report the problem.</string>
-    <string name="requesting_thumbnails">Requesting thumbnails, please be patient</string>
-</resources>

--- a/src/android/Library/res/values-de/multiimagechooser_strings_de.xml
+++ b/src/android/Library/res/values-de/multiimagechooser_strings_de.xml
@@ -4,4 +4,6 @@
     <string name="free_version_label">Free version - Images left: %d</string>
     <string name="error_database">There was an error opening the images database. Please report the problem.</string>
     <string name="requesting_thumbnails">Requesting thumbnails, please be patient</string>
+    <string name="discard">Cancel</string>
+    <string name="done">OK</string>
 </resources>

--- a/src/android/Library/res/values-de/multiimagechooser_strings_de.xml
+++ b/src/android/Library/res/values-de/multiimagechooser_strings_de.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="multi_app_name">MultiImageChooser</string>
+    <string name="free_version_label">Free version - Images left: %d</string>
+    <string name="error_database">There was an error opening the images database. Please report the problem.</string>
+    <string name="requesting_thumbnails">Requesting thumbnails, please be patient</string>
+</resources>

--- a/src/android/Library/res/values-es/multiimagechooser_strings_es.xml
+++ b/src/android/Library/res/values-es/multiimagechooser_strings_es.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="multi_app_name">MultiImageChooser</string>
-    <string name="requesting_thumbnails">Solicitando miniaturas. Por favor, espere…</string>
-    <string name="free_version_label">Versión gratuita - Imágenes restantes: %d</string>
-    <string name="error_database">Error al abrir la base de datos de imágenes.</string>
-</resources>

--- a/src/android/Library/res/values-es/multiimagechooser_strings_es.xml
+++ b/src/android/Library/res/values-es/multiimagechooser_strings_es.xml
@@ -4,4 +4,6 @@
     <string name="requesting_thumbnails">Solicitando miniaturas. Por favor, espere…</string>
     <string name="free_version_label">Versión gratuita - Imágenes restantes: %d</string>
     <string name="error_database">Error al abrir la base de datos de imágenes.</string>
+    <string name="discard">Cancelar</string>
+    <string name="done">OK</string>
 </resources>

--- a/src/android/Library/res/values-es/multiimagechooser_strings_es.xml
+++ b/src/android/Library/res/values-es/multiimagechooser_strings_es.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="multi_app_name">MultiImageChooser</string>
+    <string name="requesting_thumbnails">Solicitando miniaturas. Por favor, espere…</string>
+    <string name="free_version_label">Versión gratuita - Imágenes restantes: %d</string>
+    <string name="error_database">Error al abrir la base de datos de imágenes.</string>
+</resources>

--- a/src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml
+++ b/src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="multi_app_name">"MultiImageChooser"</string>
+    <string name="free_version_label">"La version gratuite - gauche Images:%d"</string>
+    <string name="error_database">"Il y avait une erreur d'ouvrir la base de données images. S'il vous plaît signaler le problème."</string>
+    <string name="requesting_thumbnails">"Demande de vignettes, s'il vous plaît soyez patient"</string>
+</resources>

--- a/src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml
+++ b/src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml
@@ -1,6 +1,0 @@
-<resources>
-    <string name="multi_app_name">"MultiImageChooser"</string>
-    <string name="free_version_label">"La version gratuite - gauche Images:%d"</string>
-    <string name="error_database">"Il y avait une erreur d'ouvrir la base de données images. S'il vous plaît signaler le problème."</string>
-    <string name="requesting_thumbnails">"Demande de vignettes, s'il vous plaît soyez patient"</string>
-</resources>

--- a/src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml
+++ b/src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml
@@ -1,8 +1,8 @@
 <resources>
-    <string name="multi_app_name">"MultiImageChooser"</string>
-    <string name="free_version_label">"La version gratuite - gauche Images:%d"</string>
-    <string name="error_database">"Il y avait une erreur d'ouvrir la base de données images. S'il vous plaît signaler le problème."</string>
-    <string name="requesting_thumbnails">"Demande de vignettes, s'il vous plaît soyez patient"</string>
-	<string name="discard">Cancel</string>
+    <string name="multi_app_name">MultiImageChooser</string>
+    <string name="free_version_label">Version gratuite - Images restantes:%d"</string>
+    <string name="error_database">"Il y eu une erreur avec les images. Veuillez nous signaler le problème."</string>
+    <string name="requesting_thumbnails">Récupération des vignettes, soyez patient</string>
+    <string name="discard">Annuler</string>
     <string name="done">OK</string>
 </resources>

--- a/src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml
+++ b/src/android/Library/res/values-fr/multiimagechooser_strings_fr.xml
@@ -3,4 +3,6 @@
     <string name="free_version_label">"La version gratuite - gauche Images:%d"</string>
     <string name="error_database">"Il y avait une erreur d'ouvrir la base de données images. S'il vous plaît signaler le problème."</string>
     <string name="requesting_thumbnails">"Demande de vignettes, s'il vous plaît soyez patient"</string>
+	<string name="discard">Cancel</string>
+    <string name="done">OK</string>
 </resources>

--- a/src/android/Library/res/values-hu/multiimagechooser_strings_hu.xml
+++ b/src/android/Library/res/values-hu/multiimagechooser_strings_hu.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="multi_app_name">MultiImageChooser</string>
-   
     <string name="free_version_label">Ingyenes verzió - hátralévő képek: %d</string>
     <string name="error_database">Képadatbázis megnyitási hiba történt. Kérjük, jelentse a problémát.</string>
     <string name="requesting_thumbnails">Miniatűrök lekérése, kérjük legyen türelemmel</string>
+    <string name="discard">Cancel</string>
+    <string name="done">OK</string>
 </resources>

--- a/src/android/Library/res/values-hu/multiimagechooser_strings_hu.xml
+++ b/src/android/Library/res/values-hu/multiimagechooser_strings_hu.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="multi_app_name">MultiImageChooser</string>
-   
-    <string name="free_version_label">Ingyenes verzió - hátralévő képek: %d</string>
-    <string name="error_database">Képadatbázis megnyitási hiba történt. Kérjük, jelentse a problémát.</string>
-    <string name="requesting_thumbnails">Miniatűrök lekérése, kérjük legyen türelemmel</string>
-</resources>

--- a/src/android/Library/res/values-hu/multiimagechooser_strings_hu.xml
+++ b/src/android/Library/res/values-hu/multiimagechooser_strings_hu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="multi_app_name">MultiImageChooser</string>
+   
+    <string name="free_version_label">Ingyenes verzió - hátralévő képek: %d</string>
+    <string name="error_database">Képadatbázis megnyitási hiba történt. Kérjük, jelentse a problémát.</string>
+    <string name="requesting_thumbnails">Miniatűrök lekérése, kérjük legyen türelemmel</string>
+</resources>

--- a/src/android/Library/res/values-ja/multiimagechooser_strings_ja.xml
+++ b/src/android/Library/res/values-ja/multiimagechooser_strings_ja.xml
@@ -4,4 +4,6 @@
     <string name="free_version_label">無料版 - 残りの画像: %d</string>
     <string name="error_database">画像データベースを開く際にエラーがありました。問題を報告してください。</string>
     <string name="requesting_thumbnails">サムネイルをリクエスト中です。お待ちください。</string>
+	<string name="discard">Cancel</string>
+    <string name="done">OK</string>
 </resources>

--- a/src/android/Library/res/values-ja/multiimagechooser_strings_ja.xml
+++ b/src/android/Library/res/values-ja/multiimagechooser_strings_ja.xml
@@ -1,7 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<resources>
-    <string name="multi_app_name">MultiImageChooser</string>
-    <string name="free_version_label">無料版 - 残りの画像: %d</string>
-    <string name="error_database">画像データベースを開く際にエラーがありました。問題を報告してください。</string>
-    <string name="requesting_thumbnails">サムネイルをリクエスト中です。お待ちください。</string>
-</resources>

--- a/src/android/Library/res/values-ja/multiimagechooser_strings_ja.xml
+++ b/src/android/Library/res/values-ja/multiimagechooser_strings_ja.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources>
+    <string name="multi_app_name">MultiImageChooser</string>
+    <string name="free_version_label">無料版 - 残りの画像: %d</string>
+    <string name="error_database">画像データベースを開く際にエラーがありました。問題を報告してください。</string>
+    <string name="requesting_thumbnails">サムネイルをリクエスト中です。お待ちください。</string>
+</resources>

--- a/src/android/Library/res/values-ko/multiimagechooser_strings_ko.xml
+++ b/src/android/Library/res/values-ko/multiimagechooser_strings_ko.xml
@@ -4,4 +4,6 @@
     <string name="free_version_label">무료 버전 - 남은 이미지: %d</string>
     <string name="error_database">이미지 데이터베이스를 여는 데 오류가 발생했습니다. 문제를 보고하세요.</string>
     <string name="requesting_thumbnails">썸네일 요청 중. 기다려주세요</string>
+    <string name="discard">Cancel</string>
+    <string name="done">OK</string>
 </resources>

--- a/src/android/Library/res/values-ko/multiimagechooser_strings_ko.xml
+++ b/src/android/Library/res/values-ko/multiimagechooser_strings_ko.xml
@@ -1,7 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<resources>
-    <string name="multi_app_name">MultiImageChooser</string>
-    <string name="free_version_label">무료 버전 - 남은 이미지: %d</string>
-    <string name="error_database">이미지 데이터베이스를 여는 데 오류가 발생했습니다. 문제를 보고하세요.</string>
-    <string name="requesting_thumbnails">썸네일 요청 중. 기다려주세요</string>
-</resources>

--- a/src/android/Library/res/values-ko/multiimagechooser_strings_ko.xml
+++ b/src/android/Library/res/values-ko/multiimagechooser_strings_ko.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources>
+    <string name="multi_app_name">MultiImageChooser</string>
+    <string name="free_version_label">무료 버전 - 남은 이미지: %d</string>
+    <string name="error_database">이미지 데이터베이스를 여는 데 오류가 발생했습니다. 문제를 보고하세요.</string>
+    <string name="requesting_thumbnails">썸네일 요청 중. 기다려주세요</string>
+</resources>

--- a/src/android/Library/res/values/multiimagechooser_strings_en.xml
+++ b/src/android/Library/res/values/multiimagechooser_strings_en.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="multi_app_name">MultiImageChooser</string>
     <string name="free_version_label">Free version - Images left: %d</string>
     <string name="error_database">There was an error opening the images database. Please report the problem.</string>


### PR DESCRIPTION
This should fix #66 build issues. 

I added the missing translations and left them as English as a default. This will at least let those who use cordova 5 continue to use the plugin until someone fluent can translate the remaining strings. 