### PR TITLE
Add privacy description required by iOS 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ window.imagePicker.getPictures(
     	// quality of resized image, defaults to 100
     	quality: int (0-100)
     };
+	
+### iOS 10 issues
+
+Starting from iOS 10, Apple started asking for specifying the reason for accessing the user’s photo library, therefore it's mandatory to add `NSPhotoLibraryUsageDescription` entry in the info.plist.
+
+[`NSPhotoLibraryUsageDescription`](https://developer.apple.com/library/mac/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW17) describes the reason that the app accesses the user’s photo library. When the system prompts the user to allow access, this string is displayed as part of the dialog box. In order to add this entry you must pass the variable `PHOTO_LIBRARY_USAGE_DESCRIPTION` on plugin install.
+
+Example:
+ 
+cordova plugin add cordova-plugin-image-picker --variable PHOTO_LIBRARY_USAGE_DESCRIPTION="your message"`
+
+Empty string will be added as value if you dont pass the variable 
     
 ### Note for Android Use
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,12 @@
 
 	<!-- ios -->
 	<platform name="ios">
+	<preference name="PHOTO_LIBRARY_USAGE_DESCRIPTION" default=" " />
+
+		 <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription ">
+              <string>$PHOTO_LIBRARY_USAGE_DESCRIPTION</string>
+         </config-file>
+
 		<config-file target="config.xml" parent="/*">
 			<feature name="ImagePicker">
 				<param name="ios-package" value="SOSPicker"/>


### PR DESCRIPTION
## Platforms

iOS

## What does the PR do?

Adds the required NSPhotoLibraryUsageDescription key to the info.plist by allowing to pass it's value as a variable.

Documented the usage of the variable on plugin install as iOS 10 issue.