### PR TITLE
fixed java.lang.NullPointerException at com.synconset.ImagePicker.onActivityResult(ImagePicker.java:67)

### DIFF
--- a/src/android/com/synconset/ImagePicker/ImagePicker.java
+++ b/src/android/com/synconset/ImagePicker/ImagePicker.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Bundle;
 import android.util.Log;
 
 public class ImagePicker extends CordovaPlugin {
@@ -68,5 +69,16 @@ public class ImagePicker extends CordovaPlugin {
 		} else {
 			this.callbackContext.error("No images selected");
 		}
+	}
+
+	/**
+	 * Choosing a picture launches another Activity, so we need to implement the
+	 * save/restore APIs to handle the case where the CordovaActivity is killed by the OS
+	 * before we get the launched Activity's result.
+	 *
+	 * @see http://cordova.apache.org/docs/en/dev/guide/platforms/android/plugin.html#launching-other-activities
+	 */
+	public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {
+		this.callbackContext = callbackContext;
 	}
 }


### PR DESCRIPTION
I had encountered an error as below:

```
08-30 10:26:08.321  8131  8131 E AndroidRuntime: java.lang.RuntimeException: Unable to resume activity {com.lifullfam.app/com.lifullfam.app.MainActivity}: java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=0, result=-1, data=Intent { (has extras) }} to activity {com.lifullfam.app/com.lifullfam.app.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.apache.cordova.CallbackContext.success(org.json.JSONArray)' on a null object reference
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3103)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3134)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2481)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.app.ActivityThread.-wrap11(ActivityThread.java)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.os.Handler.dispatchMessage(Handler.java:102)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.os.Looper.loop(Looper.java:148)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.app.ActivityThread.main(ActivityThread.java:5417)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at java.lang.reflect.Method.invoke(Native Method)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.app.ActivityThread.deliverResults(ActivityThread.java:3699)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3089)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    ... 10 more
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at com.synconset.ImagePicker.onActivityResult(ImagePicker.java:67)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at org.apache.cordova.CordovaInterfaceImpl.onActivityResult(CordovaInterfaceImpl.java:151)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at org.apache.cordova.CordovaActivity.onActivityResult(CordovaActivity.java:348)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.app.Activity.dispatchActivityResult(Activity.java:6428)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    at android.app.ActivityThread.deliverResults(ActivityThread.java:3695)
08-30 10:26:08.321  8131  8131 E AndroidRuntime:    ... 11 more
```

The error seems to be related with [CB-9189](https://issues.apache.org/jira/browse/CB-9189), which was fixed by this apache/cordova-plugin-camera#145.

This PR fixes the case when the CordovaActivity was killed by the android OS while launching another Activity.
This might also fixes #170.
