### PR TITLE
Disabling dismissing of the ProgressDialog

### DIFF
--- a/src/android/Library/src/MultiImageChooserActivity.java
+++ b/src/android/Library/src/MultiImageChooserActivity.java
@@ -173,6 +173,7 @@ public class MultiImageChooserActivity extends Activity implements OnItemClickLi
         setupHeader();
         updateAcceptButton();
         progress = new ProgressDialog(this);
+	progress.setCancelable(false);
         progress.setTitle("Processing Images");
         progress.setMessage("This may take a few moments");
     }


### PR DESCRIPTION
Clicking on the screen dismisses the dialog. If you select an image afterwards the whole applications crashes.
